### PR TITLE
Fix URL to chalmers card top-up

### DIFF
--- a/dtekportal/templates/header/header-menu-box.html
+++ b/dtekportal/templates/header/header-menu-box.html
@@ -114,7 +114,7 @@
                 {% trans "Kårkort" %}
             {% endmacro_arg %}
             {% macro_arg %}
-                https://kårkort.se
+                https://kortladdning3.chalmerskonferens.se
             {% endmacro_arg %}
             {% macro_arg %}
                 {% trans "Genväg för att ladda ditt kårkort" %}


### PR DESCRIPTION
Updated the top-up link to the current official link.

I have not been able to verify that this works as expected because the web-service failed when I tried to run `docker-compose up`.