### PR TITLE
Bump Django from 2.1.1 to 2.1.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==2.1.1
+Django==2.1.2
 django-macros==0.4.0
 psycopg2==2.7.5
 pytz==2018.5


### PR DESCRIPTION
Django 2.1 is affected by the following security issue
https://nvd.nist.gov/vuln/detail/CVE-2018-16984 (reported by Github).
This remedies the security issue by bumping Django to the patched
version.

N.B I could not test this, but assuming that they use semver (semantic
versioning) bumping a patch version should not affect
behaviour (unless we exploit the security issue).