### PR TITLE
Adding committees and making them more consistent

### DIFF
--- a/dtekportal/templates/footer/footer-right-col.html
+++ b/dtekportal/templates/footer/footer-right-col.html
@@ -155,4 +155,20 @@
             <dd><a href="https://date-it.se">DatE-IT</a></dd>
         </div>
     </div>
+    <div class="row">
+        <div class="column small-6 large-8 text-right">
+            <dt>{% trans "Bakkommitté" %}</dt>
+        </div>
+        <div class="column small-6 large-4">
+            <dd><a href="https://wiki.dtek.se/wiki/BakaD">BakaD</a></dd>
+        </div>
+    </div>
+    <div class="row">
+        <div class="column small-6 large-8 text-right">
+            <dt>{% trans "Finsmakarkommitté" %}</dt>
+        </div>
+        <div class="column small-6 large-4">
+            <dd><a href="https://wiki.dtek.se/wiki/DSL">DSL</a></dd>
+        </div>
+    </div>
 </section>

--- a/dtekportal/templates/footer/footer-right-col.html
+++ b/dtekportal/templates/footer/footer-right-col.html
@@ -61,7 +61,7 @@
     </div>
     <div class="row">
         <div class="column small-6 large-8 text-right">
-            <dt>{% trans "DATA-driftsförening" %}</dt>
+            <dt>{% trans "Serverdriftskommitté" %}</dt>
         </div>
         <div class="column small-6 large-4">
             <dd><a href="https://wiki.dtek.se/wiki/DHack">dHack</a></dd>
@@ -77,7 +77,7 @@
     </div>
     <div class="row">
         <div class="column small-6 large-8 text-right">
-            <dt>{% trans "Idrottsförening" %}</dt>
+            <dt>{% trans "Idrottskommitté" %}</dt>
         </div>
         <div class="column small-6 large-4">
             <dd><a href="https://wiki.dtek.se/wiki/IDrott">iDrott</a></dd>
@@ -85,7 +85,7 @@
     </div>
     <div class="row">
         <div class="column small-6 large-8 text-right">
-            <dt>{% trans "Spelförening" %}</dt>
+            <dt>{% trans "Spelkommitté" %}</dt>
         </div>
         <div class="column small-6 large-4">
             <dd><a href="https://wiki.dtek.se/wiki/DLude">DLude</a></dd>

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-15 16:46+0100\n"
+"POT-Creation-Date: 2025-02-19 22:00+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -220,8 +220,10 @@ msgid "Arbetsmarknadsgrupp"
 msgstr "Career and Business Relations"
 
 #: templates/footer/footer-right-col.html:64
+#, fuzzy
+#| msgid "Bilkommitté"
 msgid "Serverdriftskommitté"
-msgstr "System administration Committee"
+msgstr "Division Car Maintainers"
 
 #: templates/footer/footer-right-col.html:72
 msgid "Fanbärare"
@@ -229,7 +231,7 @@ msgstr "Flag-Bearers"
 
 #: templates/footer/footer-right-col.html:80
 msgid "Idrottskommitté"
-msgstr "Sports Committee"
+msgstr "Sports committee"
 
 #: templates/footer/footer-right-col.html:88
 msgid "Spelkommitté"
@@ -273,7 +275,7 @@ msgstr "Baking Committee"
 
 #: templates/footer/footer-right-col.html:168
 msgid "Finsmakarkommitté"
-msgstr "Connoisseur Committee"
+msgstr "Connosieur Committee"
 
 #: templates/head.html:14
 msgid "Datateknologsektionen på Chalmers"
@@ -379,3 +381,21 @@ msgstr "Studies"
 #: templates/top-nav-banner.html:23
 msgid "Foton"
 msgstr "Photos"
+
+#~ msgid "DATA-driftsförening"
+#~ msgstr "System Administrators"
+
+#~ msgid "Idrottsförening"
+#~ msgstr "Sports Committee"
+
+#~ msgid "Spelförening"
+#~ msgstr "Gaming Committee"
+
+#~ msgid "Kårkort"
+#~ msgstr "Student Union Card"
+
+#~ msgid "Genväg för att ladda ditt kårkort"
+#~ msgstr "Shortcut to charge your student union card"
+
+#~ msgid "Sektionen på Facebook"
+#~ msgstr "The divison on Facebook"

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-15 16:37+0100\n"
+"POT-Creation-Date: 2025-02-15 16:46+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -220,19 +220,19 @@ msgid "Arbetsmarknadsgrupp"
 msgstr "Career and Business Relations"
 
 #: templates/footer/footer-right-col.html:64
-msgid "DATA-driftsförening"
-msgstr "System Administrators"
+msgid "Serverdriftskommitté"
+msgstr "System administration Committee"
 
 #: templates/footer/footer-right-col.html:72
 msgid "Fanbärare"
 msgstr "Flag-Bearers"
 
 #: templates/footer/footer-right-col.html:80
-msgid "Idrottsförening"
+msgid "Idrottskommitté"
 msgstr "Sports Committee"
 
 #: templates/footer/footer-right-col.html:88
-msgid "Spelförening"
+msgid "Spelkommitté"
 msgstr "Gaming Committee"
 
 #: templates/footer/footer-right-col.html:96
@@ -379,4 +379,3 @@ msgstr "Studies"
 #: templates/top-nav-banner.html:23
 msgid "Foton"
 msgstr "Photos"
-

--- a/locale/en/LC_MESSAGES/django.po
+++ b/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-14 14:35+0100\n"
+"POT-Creation-Date: 2025-02-15 16:37+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -267,6 +267,14 @@ msgstr "Equality Committee"
 msgid "Arbetsmarknadsmässa"
 msgstr "Career Fair"
 
+#: templates/footer/footer-right-col.html:160
+msgid "Bakkommitté"
+msgstr "Baking Committee"
+
+#: templates/footer/footer-right-col.html:168
+msgid "Finsmakarkommitté"
+msgstr "Connoisseur Committee"
+
 #: templates/head.html:14
 msgid "Datateknologsektionen på Chalmers"
 msgstr "Division of Computer Science and Engineering at Chalmers"
@@ -371,3 +379,4 @@ msgstr "Studies"
 #: templates/top-nav-banner.html:23
 msgid "Foton"
 msgstr "Photos"
+

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-15 16:46+0100\n"
+"POT-Creation-Date: 2025-02-19 22:00+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -249,7 +249,7 @@ msgstr "Sektionens podcast"
 
 #: templates/footer/footer-right-col.html:128
 msgid "Master Reception Committee"
-msgstr "Master Reception Committee"
+msgstr "Mastermottagningskommitté"
 
 #: templates/footer/footer-right-col.html:136
 msgid "Matlagningskommitté"
@@ -264,12 +264,16 @@ msgid "Arbetsmarknadsmässa"
 msgstr "Arbetsmarknadsmässa"
 
 #: templates/footer/footer-right-col.html:160
+#, fuzzy
+#| msgid "Bilkommitté"
 msgid "Bakkommitté"
-msgstr "Bakkommitté"
+msgstr "Bilkommitté"
 
 #: templates/footer/footer-right-col.html:168
+#, fuzzy
+#| msgid "Bilkommitté"
 msgid "Finsmakarkommitté"
-msgstr "Finsmakarkommitté"
+msgstr "Bilkommitté"
 
 #: templates/head.html:14
 msgid "Datateknologsektionen på Chalmers"
@@ -377,3 +381,21 @@ msgstr "Studier"
 #: templates/top-nav-banner.html:23
 msgid "Foton"
 msgstr "Foton"
+
+#~ msgid "DATA-driftsförening"
+#~ msgstr "DATA-driftsförening"
+
+#~ msgid "Idrottsförening"
+#~ msgstr "Idrottsförening"
+
+#~ msgid "Spelförening"
+#~ msgstr "Spelförening"
+
+#~ msgid "Kårkort"
+#~ msgstr "Kårkort"
+
+#~ msgid "Genväg för att ladda ditt kårkort"
+#~ msgstr "Genväg för att ladda ditt kårkort"
+
+#~ msgid "Sektionen på Facebook"
+#~ msgstr "Sektionen på Facebook"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-15 16:37+0100\n"
+"POT-Creation-Date: 2025-02-15 16:46+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -216,20 +216,20 @@ msgid "Arbetsmarknadsgrupp"
 msgstr "Arbetsmarknadsgrupp"
 
 #: templates/footer/footer-right-col.html:64
-msgid "DATA-driftsförening"
-msgstr "DATA-driftsförening"
+msgid "Serverdriftskommitté"
+msgstr "Serverdriftskommitté"
 
 #: templates/footer/footer-right-col.html:72
 msgid "Fanbärare"
 msgstr "Fanbärare"
 
 #: templates/footer/footer-right-col.html:80
-msgid "Idrottsförening"
-msgstr "Idrottsförening"
+msgid "Idrottskommitté"
+msgstr "Idrottskommitté"
 
 #: templates/footer/footer-right-col.html:88
-msgid "Spelförening"
-msgstr "Spelförening"
+msgid "Spelkommitté"
+msgstr "Spelkommitté"
 
 #: templates/footer/footer-right-col.html:96
 msgid "Fotokommitté"

--- a/locale/sv/LC_MESSAGES/django.po
+++ b/locale/sv/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-14 14:35+0100\n"
+"POT-Creation-Date: 2025-02-15 16:37+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -262,6 +262,14 @@ msgstr "Jämlikhetskommitté"
 #: templates/footer/footer-right-col.html:152
 msgid "Arbetsmarknadsmässa"
 msgstr "Arbetsmarknadsmässa"
+
+#: templates/footer/footer-right-col.html:160
+msgid "Bakkommitté"
+msgstr "Bakkommitté"
+
+#: templates/footer/footer-right-col.html:168
+msgid "Finsmakarkommitté"
+msgstr "Finsmakarkommitté"
 
 #: templates/head.html:14
 msgid "Datateknologsektionen på Chalmers"


### PR DESCRIPTION
BakaD och DSL saknades ifrån listan på hemsidan, utöver det så var namnen på kommittéerna inte konsekvent, då några kallades föreningar och vissa kallades kommittéer. Nu är det inte helt perfekt men det är något bättre än förut, och tror vi är värt att göra inför det potentiella införandet av intresseföreningar. 